### PR TITLE
Add build instructions for the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Battlecode Client
 
 *NOTE: If you are a competitor, you can download the installer that does all these steps for you. See http://www.battlecode.org/contestants/releases/.*
 
+Basic Guide to Building
+-----------------------
+1. First build battlecode-server (https://github.com/battlecode/battlecode-server)
+2. copy the jar file from battlecode-server into battlecode-client's directory `lib/compile`
+3. `ant retrieve` get remaining dependencies.
+4. `ant` perform compilation and building.
+5. `ant jar` package the jar file.
+
 Basic Guide to the Codebase
 ---------------------------
 


### PR DESCRIPTION
Client build process seems to require a working version of the battle-code server jar to be present. Since this is non-obvious, I have added some brief documentation on how to get this up and running.

Ideally, fetching this should be done as part of the `ant retrieve` step, but I don't know if that's feasible.