### PR TITLE
Let tests run correctly with ant 1.9.3.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -193,7 +193,7 @@
     <!-- ========== TESTING ========= -->
 
     <target name="unittest" depends="compiletest">
-        <junit printsummary="withOutAndErr" timeout="${test.timeout}" filtertrace="off" failureproperty="test.failed" fork="true">
+        <junit printsummary="withOutAndErr" timeout="${test.timeout}" filtertrace="off" failureproperty="test.failed" fork="true" forkmode="once">
             <classpath refid="classpath-libs"/>
             <classpath refid="classpath-test-libs"/>
             <classpath>

--- a/build.xml
+++ b/build.xml
@@ -193,7 +193,7 @@
     <!-- ========== TESTING ========= -->
 
     <target name="unittest" depends="compiletest">
-        <junit printsummary="withOutAndErr" timeout="${test.timeout}" filtertrace="off" failureproperty="test.failed">
+        <junit printsummary="withOutAndErr" timeout="${test.timeout}" filtertrace="off" failureproperty="test.failed" fork="true">
             <classpath refid="classpath-libs"/>
             <classpath refid="classpath-test-libs"/>
             <classpath>


### PR DESCRIPTION
Recent versions of ant pull in their own junit libraries, and this seems to cause conflict with the junit used by battlecode's tests.

This results in the following error after runing 'ant junit'

java.lang.NoClassDefFoundError: junit/framework/JUnit4TestAdapterCache

This has been noticed in other repositories:

https://github.com/real-logic/simple-binary-encoding/issues/96/

The simplest solution is to fork the test vm, which prevents the
invalid version of ant from being brought in.