### PR TITLE
Pre render broadcast

### DIFF
--- a/src/main/battlecode/client/util/PrerenderedGraphics.java
+++ b/src/main/battlecode/client/util/PrerenderedGraphics.java
@@ -3,6 +3,7 @@ package battlecode.client.util;
 import battlecode.client.viewer.render.RenderConfiguration;
 
 import java.awt.*;
+import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
@@ -10,6 +11,8 @@ import java.awt.image.BufferedImage;
  * A class that pre-renders images so that we don't have to draw them later.
  */
 public class PrerenderedGraphics {
+    private static final Stroke thinStroke = new BasicStroke(0.05f);
+
     private BufferedImage broadcastImage;
     private BufferedImage zombieInfectionImage;
     private BufferedImage viperInfectionImage;
@@ -19,27 +22,34 @@ public class PrerenderedGraphics {
     }
 
     public void prerender(float spriteSize) {
-        prerenderBroadcastImage(RenderConfiguration.getInstance().getSpriteSize
+        prerenderBroadcastImage((int) RenderConfiguration.getInstance()
+                .getSpriteSize
                 ());
-        prerenderInfectionImages(RenderConfiguration.getInstance()
+        prerenderInfectionImages((int) RenderConfiguration.getInstance()
                 .getSpriteSize());
     }
 
-    public void prerenderBroadcastImage(float spriteSize) {
-        broadcastImage = new BufferedImage((int) Math.ceil(spriteSize),
-                (int) Math.ceil(spriteSize), BufferedImage.TYPE_INT_ARGB);
+    public void prerenderBroadcastImage(int spriteSize) {
+        broadcastImage = new BufferedImage(3 * spriteSize, 3 * spriteSize, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2 = broadcastImage.createGraphics();
+        g2.setStroke(thinStroke);
+        g2.setColor(new Color(1, 0, 1, 0.75f));
+        for (int i = 3; i <= 5; i++) {
+            double r = i * 0.2 * spriteSize;
+            g2.draw(new Ellipse2D.Double(1.5 * spriteSize - r, 1.5 * spriteSize
+                    - r, 2 * r, 2 * r));
+        }
         g2.dispose();
     }
 
-    public void prerenderInfectionImages(float spriteSize) {
+    public void prerenderInfectionImages(int spriteSize) {
         Color green = new Color(0.5f, 1.0f, 0.5f, 1.0f);
         Color purple = new Color(0.5f, 0.15f, 0.8f, 1.0f);
         zombieInfectionImage = getInfectionImage(spriteSize, green);
         viperInfectionImage = getInfectionImage(spriteSize, purple);
     }
 
-    public BufferedImage getInfectionImage(float spriteSize, Color
+    public BufferedImage getInfectionImage(int spriteSize, Color
         infectionColor) {
         BufferedImage result = new BufferedImage((int) Math.ceil(spriteSize),
                 (int) Math.ceil(spriteSize), BufferedImage.TYPE_INT_ARGB);

--- a/src/main/battlecode/client/util/PrerenderedGraphics.java
+++ b/src/main/battlecode/client/util/PrerenderedGraphics.java
@@ -1,0 +1,86 @@
+package battlecode.client.util;
+
+import battlecode.client.viewer.render.RenderConfiguration;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+/**
+ * A class that pre-renders images so that we don't have to draw them later.
+ */
+public class PrerenderedGraphics {
+    private BufferedImage broadcastImage;
+    private BufferedImage zombieInfectionImage;
+    private BufferedImage viperInfectionImage;
+
+    public PrerenderedGraphics() {
+        prerender(RenderConfiguration.getInstance().getSpriteSize());
+    }
+
+    public void prerender(float spriteSize) {
+        prerenderBroadcastImage(RenderConfiguration.getInstance().getSpriteSize
+                ());
+        prerenderInfectionImages(RenderConfiguration.getInstance()
+                .getSpriteSize());
+    }
+
+    public void prerenderBroadcastImage(float spriteSize) {
+        broadcastImage = new BufferedImage((int) Math.ceil(spriteSize),
+                (int) Math.ceil(spriteSize), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = broadcastImage.createGraphics();
+        g2.dispose();
+    }
+
+    public void prerenderInfectionImages(float spriteSize) {
+        Color green = new Color(0.5f, 1.0f, 0.5f, 1.0f);
+        Color purple = new Color(0.5f, 0.15f, 0.8f, 1.0f);
+        zombieInfectionImage = getInfectionImage(spriteSize, green);
+        viperInfectionImage = getInfectionImage(spriteSize, purple);
+    }
+
+    public BufferedImage getInfectionImage(float spriteSize, Color
+        infectionColor) {
+        BufferedImage result = new BufferedImage((int) Math.ceil(spriteSize),
+                (int) Math.ceil(spriteSize), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = result.createGraphics();
+
+        g2.setColor(infectionColor);
+        Rectangle2D.Float rectLeft;
+        rectLeft = new Rectangle2D.Float(0.02f * spriteSize, 0, 0.1f *
+                spriteSize, 1 * spriteSize);
+        g2.fill(rectLeft);
+        rectLeft = new Rectangle2D.Float(0.12f * spriteSize, 0, 0.2f *
+                spriteSize, 0.1f * spriteSize);
+        g2.fill(rectLeft);
+        rectLeft = new Rectangle2D.Float(0.12f * spriteSize,0.9f *
+                spriteSize, 0.2f * spriteSize, 0.1f * spriteSize);
+        g2.fill(rectLeft);
+
+        Rectangle2D.Float rectRight;
+        rectRight = new Rectangle2D.Float(0.88f * spriteSize, 0, 0.1f *
+                spriteSize, 1 * spriteSize);
+        g2.fill(rectRight);
+        rectRight = new Rectangle2D.Float(0.68f * spriteSize, 0, 0.2f *
+                spriteSize, 0.1f * spriteSize);
+        g2.fill(rectRight);
+        rectRight = new Rectangle2D.Float(0.68f * spriteSize, 0.9f *
+                spriteSize, 0.2f * spriteSize, 0.1f * spriteSize);
+        g2.fill(rectRight);
+        g2.dispose();
+
+        return result;
+    }
+
+    public BufferedImage getBroadcastImage() {
+        return broadcastImage;
+    }
+
+    public BufferedImage getZombieInfectionImage() {
+        return zombieInfectionImage;
+    }
+
+    public BufferedImage getViperInfectionImage() {
+        return viperInfectionImage;
+    }
+}

--- a/src/main/battlecode/client/viewer/AbstractDrawObject.java
+++ b/src/main/battlecode/client/viewer/AbstractDrawObject.java
@@ -92,7 +92,6 @@ public abstract class AbstractDrawObject {
     protected int bytecodesUsed = 0;
     protected double attackDelay = 0;
     protected double movementDelay = 0;
-    protected final int visualBroadcastRadius = 2;
     protected boolean turnedOn = true;
     protected boolean loaded = false;
     protected int regen = 0;
@@ -215,7 +214,7 @@ public abstract class AbstractDrawObject {
     }
 
     public void setBroadcast() {
-        broadcast++;
+        broadcast = 3;
     }
 
     public void setZombieInfectedTurns(int zombieInfectedTurns) {
@@ -298,7 +297,7 @@ public abstract class AbstractDrawObject {
 
         updateDrawLoc();
 
-        broadcast = (broadcast << 1) & 0x000FFFFF;
+        broadcast = Math.max(0, broadcast - 1);
         if (regen > 0) regen--;
 
         Iterator<Map.Entry<Animation.AnimationType, Animation>> it =

--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -303,8 +303,6 @@ public class DrawObject extends AbstractDrawObject {
                     infection = pg.getViperInfectionImage();
                 }
                 AffineTransform trans = new AffineTransform();
-                System.out.println(infection.getWidth() + " " + infection
-                        .getHeight());
                 trans.scale(1.0 / infection.getWidth(), 1.0 /
                         infection.getHeight());
                 g2.drawImage(infection, trans, null);

--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -292,6 +292,35 @@ public class DrawObject extends AbstractDrawObject {
             g2.setColor(new Color(1f, 0f, 0f));
             g2.fill(rect);
         }
+
+        if (RenderConfiguration.showInfectionIndicators()) {
+            if (getViperInfectedTurns() > 0 || getZombieInfectedTurns() > 0) {
+                // If viper infected (or both), use purple.
+                // If zombie infected, use green.
+
+                Color infectionColor = new Color(0.5f, 1.0f, 0.5f, 1.0f);
+                if (getViperInfectedTurns() > 0) {
+                    infectionColor = new Color(0.5f, 0.15f, 0.8f, 1.0f);
+                }
+
+                g2.setColor(infectionColor);
+                Rectangle2D.Float rectLeft;
+                rectLeft = new Rectangle2D.Float(0.02f,0,0.1f, 1);
+                g2.fill(rectLeft);
+                rectLeft = new Rectangle2D.Float(0.12f,0,0.2f,0.1f);
+                g2.fill(rectLeft);
+                rectLeft = new Rectangle2D.Float(0.12f,0.9f,0.2f,0.1f);
+                g2.fill(rectLeft);
+
+                Rectangle2D.Float rectRight;
+                rectRight = new Rectangle2D.Float(0.88f,0,0.1f, 1);
+                g2.fill(rectRight);
+                rectRight = new Rectangle2D.Float(0.68f,0,0.2f,0.1f);
+                g2.fill(rectRight);
+                rectRight = new Rectangle2D.Float(0.68f,0.9f,0.2f,0.1f);
+                g2.fill(rectRight);
+            }
+        }
     }
 
     public double drawScale() {

--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -2,6 +2,7 @@ package battlecode.client.viewer.render;
 
 import battlecode.client.util.ImageFile;
 import battlecode.client.util.ImageResource;
+import battlecode.client.util.PrerenderedGraphics;
 import battlecode.client.util.SpriteSheetFile;
 import battlecode.client.viewer.AbstractDrawObject;
 import battlecode.client.viewer.Action;
@@ -36,6 +37,8 @@ public class DrawObject extends AbstractDrawObject {
     private static final ImageFile hatchAttack = new ImageFile
             ("art/hatch_attack.png");
     private static final ImageFile creep = new ImageFile("art/creep.png");
+    private static final PrerenderedGraphics pg = new PrerenderedGraphics();
+
     private ImageFile img;
 
     public static final Animation.AnimationType[] preDrawOrder = new
@@ -295,30 +298,16 @@ public class DrawObject extends AbstractDrawObject {
 
         if (RenderConfiguration.showInfectionIndicators()) {
             if (getViperInfectedTurns() > 0 || getZombieInfectedTurns() > 0) {
-                // If viper infected (or both), use purple.
-                // If zombie infected, use green.
-
-                Color infectionColor = new Color(0.5f, 1.0f, 0.5f, 1.0f);
+                BufferedImage infection = pg.getZombieInfectionImage();
                 if (getViperInfectedTurns() > 0) {
-                    infectionColor = new Color(0.5f, 0.15f, 0.8f, 1.0f);
+                    infection = pg.getViperInfectionImage();
                 }
-
-                g2.setColor(infectionColor);
-                Rectangle2D.Float rectLeft;
-                rectLeft = new Rectangle2D.Float(0.02f,0,0.1f, 1);
-                g2.fill(rectLeft);
-                rectLeft = new Rectangle2D.Float(0.12f,0,0.2f,0.1f);
-                g2.fill(rectLeft);
-                rectLeft = new Rectangle2D.Float(0.12f,0.9f,0.2f,0.1f);
-                g2.fill(rectLeft);
-
-                Rectangle2D.Float rectRight;
-                rectRight = new Rectangle2D.Float(0.88f,0,0.1f, 1);
-                g2.fill(rectRight);
-                rectRight = new Rectangle2D.Float(0.68f,0,0.2f,0.1f);
-                g2.fill(rectRight);
-                rectRight = new Rectangle2D.Float(0.68f,0.9f,0.2f,0.1f);
-                g2.fill(rectRight);
+                AffineTransform trans = new AffineTransform();
+                System.out.println(infection.getWidth() + " " + infection
+                        .getHeight());
+                trans.scale(1.0 / infection.getWidth(), 1.0 /
+                        infection.getHeight());
+                g2.drawImage(infection, trans, null);
             }
         }
     }

--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -367,16 +367,13 @@ public class DrawObject extends AbstractDrawObject {
 
     // draw translated to robot location
     public void drawBroadcast(Graphics2D g2) {
-        if (broadcast != 0x00 && RenderConfiguration.showBroadcast()) {
-            g2.setStroke(broadcastStroke);
-            double drdR = visualBroadcastRadius * 0.05; // dradius/dRound
-            for (int i = 0; i < 15; i++) {
-                if ((broadcast & (1 << i)) != 0x00) {
-                    double r = i * drdR;
-                    g2.setColor(new Color(1, 0, 1, 0.05f * (15 - i)));
-                    g2.draw(new Ellipse2D.Double(0.5 - r, 0.5 - r, 2 * r, 2 * r));
-                }
-            }
+        if (broadcast > 0 && RenderConfiguration.showBroadcast()) {
+            BufferedImage broadcast = pg.getBroadcastImage();
+            AffineTransform trans = new AffineTransform();
+            trans.translate(-1.0f, -1.0f);
+            trans.scale(3.0 / broadcast.getWidth(), 3.0 /
+                    broadcast.getHeight());
+            g2.drawImage(broadcast, trans, null);
         }
     }
 

--- a/src/main/battlecode/client/viewer/render/GameRenderer.java
+++ b/src/main/battlecode/client/viewer/render/GameRenderer.java
@@ -404,7 +404,7 @@ public class GameRenderer {
                 RenderConfiguration.toggleAmbientMusic();
                 break;
             case 'L':
-                RenderConfiguration.toggleSupplyIndicators();
+                RenderConfiguration.toggleInfectionIndicators();
                 break;
             case 'O':
                 RenderConfiguration.toggleShowHats();

--- a/src/main/battlecode/client/viewer/render/RenderConfiguration.java
+++ b/src/main/battlecode/client/viewer/render/RenderConfiguration.java
@@ -25,7 +25,7 @@ public class RenderConfiguration {
     private static boolean parts = true;
     private static int indicatorDotToggles;
     private static boolean supplyTransfers = true;
-    private static boolean supplyIndicators = true;
+    private static boolean infectionIndicators = true;
 
     private static boolean tournamentMode = false;
 
@@ -105,8 +105,8 @@ public class RenderConfiguration {
         supplyTransfers = !supplyTransfers;
     }
 
-    public static void toggleSupplyIndicators() {
-        supplyIndicators = !supplyIndicators;
+    public static void toggleInfectionIndicators() {
+        infectionIndicators = !infectionIndicators;
     }
 
     public static void toggleParts() {
@@ -173,6 +173,10 @@ public class RenderConfiguration {
 
     public static boolean showIndicatorDots(Team t) {
         return ((indicatorDotToggles >> t.ordinal()) & 1) != 0;
+    }
+
+    public static boolean showInfectionIndicators() {
+        return infectionIndicators;
     }
 
     public static boolean playAmbientMusic() {


### PR DESCRIPTION
Not ready to merge. Attempt to speed up and declutter broadcast by pre-rendering the images. Now it only flashes 3 circles for one turn when there is a broadcast, instead of displaying the fancy animation.

Not ready for merge because it shows up poorly when the resolution is low.

I also didn't set up this pull request right (it should be branched off of infection2).