### PR TITLE
fix keyframes issue

### DIFF
--- a/src/main/battlecode/client/viewer/AbstractDrawObject.java
+++ b/src/main/battlecode/client/viewer/AbstractDrawObject.java
@@ -60,9 +60,14 @@ public abstract class AbstractDrawObject {
         loaded = copy.loaded;
         regen = copy.regen;
 
-        actions = (LinkedList<Action>) actions.clone();
+        actions = (LinkedList<Action>) copy.actions.clone();
         attackDelay = copy.attackDelay;
         movementDelay = copy.movementDelay;
+
+        buildDelay = copy.buildDelay;
+        zombieInfectedTurns = copy.zombieInfectedTurns;
+        viperInfectedTurns = copy.viperInfectedTurns;
+        aliveRounds = copy.aliveRounds;
 
         hats = copy.hats;
 


### PR DESCRIPTION
Every 10 rounds, there is a keyframe. Keyframes have their DrawState stored in memory. When we want to play back a round, we go to the nearest keyframe, and then recompute the target round by using the keyframe round.

Unfortunately keyframes relied on this DrawState constructor to properly copy an old DrawState to a new one. The constructor didn't copy all the variables over, which resulted in every 10 turns the robots having wrong values (wrong infection counts and not showing their attack status).