### PR TITLE
Resize sprites more intelligently and cache the resized versions

### DIFF
--- a/src/main/battlecode/client/util/ImageFile.java
+++ b/src/main/battlecode/client/util/ImageFile.java
@@ -6,11 +6,9 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.HashMap;
 
 public class ImageFile {
     public BufferedImage image;
-    private HashMap<Dimension, BufferedImage> cache;
 
     public ImageFile(String pathname) {
         try {
@@ -25,17 +23,12 @@ public class ImageFile {
         } catch (IOException e) {
             image = null;
         }
-        cache = new HashMap<>();
-        cache.put(new Dimension(image.getWidth(), image.getHeight()), image);
     }
 
-    public ImageFile(BufferedImage image) {
-        this.image = image;
-    }
-
-    public void resize(int width, int height) {
-        this.image = getScaledInstance(image, width, height,
-                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    public ImageFile(String pathname, int width, int height) {
+        this(pathname);
+        this.image = getScaledInstance(image, width, height, RenderingHints
+                .VALUE_INTERPOLATION_BILINEAR);
     }
 
     // Temporary resizing algorithm, taken from http://stackoverflow.com/questions/24745147/java-resize-image-without-losing-quality
@@ -73,6 +66,8 @@ public class ImageFile {
 
             BufferedImage tmp = new BufferedImage(w, h, type);
             Graphics2D g2 = tmp.createGraphics();
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON);
             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
             g2.drawImage(ret, 0, 0, w, h, null);
             g2.dispose();

--- a/src/main/battlecode/client/util/ImageFile.java
+++ b/src/main/battlecode/client/util/ImageFile.java
@@ -6,9 +6,11 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.HashMap;
 
 public class ImageFile {
     public BufferedImage image;
+    private HashMap<Dimension, BufferedImage> cache;
 
     public ImageFile(String pathname) {
         try {
@@ -23,5 +25,61 @@ public class ImageFile {
         } catch (IOException e) {
             image = null;
         }
+        cache = new HashMap<>();
+        cache.put(new Dimension(image.getWidth(), image.getHeight()), image);
+    }
+
+    public ImageFile(BufferedImage image) {
+        this.image = image;
+    }
+
+    public void resize(int width, int height) {
+        this.image = getScaledInstance(image, width, height,
+                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    }
+
+    // Temporary resizing algorithm, taken from http://stackoverflow.com/questions/24745147/java-resize-image-without-losing-quality
+    public static BufferedImage getScaledInstance(BufferedImage img, int targetWidth,
+                                                  int targetHeight, Object hint) {
+        int type = (img.getTransparency() == Transparency.OPAQUE) ? BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+        BufferedImage ret = img;
+        int w = img.getWidth();
+        int h = img.getHeight();
+
+        do {
+            if (w > targetWidth) {
+                w /= 2;
+                if (w < targetWidth) {
+                    w = targetWidth;
+                }
+            } else {
+                w *= 2;
+                if (w > targetWidth) {
+                    w = targetWidth;
+                }
+            }
+
+            if (h > targetHeight) {
+                h /= 2;
+                if (h < targetHeight) {
+                    h = targetHeight;
+                }
+            } else {
+                h *= 2;
+                if (h > targetHeight) {
+                    h = targetHeight;
+                }
+            }
+
+            BufferedImage tmp = new BufferedImage(w, h, type);
+            Graphics2D g2 = tmp.createGraphics();
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
+            g2.drawImage(ret, 0, 0, w, h, null);
+            g2.dispose();
+
+            ret = tmp;
+        } while (w != targetWidth || h != targetHeight);
+
+        return ret;
     }
 }

--- a/src/main/battlecode/client/util/ImageResource.java
+++ b/src/main/battlecode/client/util/ImageResource.java
@@ -1,32 +1,39 @@
 package battlecode.client.util;
 
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ImageResource<E> {
 
-    private final Map<E, ImageFile> cache;
+    private final Map<E, Map<Dimension, ImageFile>> cache;
+
 
     public ImageResource() {
         cache = new HashMap<>();
     }
 
     public ImageFile getResource(E key, String path) {
-        return getResource(key, path, false);
+        return getResource(key, path, 0, 0);
     }
 
-    public ImageFile getResource(E key, String path, boolean useSpriteSheet) {
-        ImageFile img = cache.get(key);
-        if (img != null) {
+    public ImageFile getResource(E key, String path, int width, int height) {
+        if (cache.get(key) != null) {
+            ImageFile img = cache.get(key).get(new Dimension(width, height));
+            if (img != null) {
+                return img;
+            }
+        }
+        ImageFile img = new ImageFile(path);
+        if (width == 0 || height == 0) {
             return img;
         }
-        if (useSpriteSheet) {
-            img = new SpriteSheetFile(path);
-        } else {
-            img = new ImageFile(path);
+        img.resize(width, height);
+        if (cache.get(key) == null) {
+            cache.put(key, new HashMap<>());
         }
-        cache.put(key, img);
+        cache.get(key).put(new Dimension(width, height), img);
         return img;
     }
 }
-

--- a/src/main/battlecode/client/util/ImageResource.java
+++ b/src/main/battlecode/client/util/ImageResource.java
@@ -9,7 +9,6 @@ public class ImageResource<E> {
 
     private final Map<E, Map<Dimension, ImageFile>> cache;
 
-
     public ImageResource() {
         cache = new HashMap<>();
     }
@@ -18,6 +17,10 @@ public class ImageResource<E> {
         return getResource(key, path, 0, 0);
     }
 
+    /**
+     * If either width or height are 0, then we return an unresized version
+     * of the image denoted by the key or path.
+     */
     public ImageFile getResource(E key, String path, int width, int height) {
         if (cache.get(key) != null) {
             ImageFile img = cache.get(key).get(new Dimension(width, height));
@@ -25,11 +28,10 @@ public class ImageResource<E> {
                 return img;
             }
         }
-        ImageFile img = new ImageFile(path);
         if (width == 0 || height == 0) {
-            return img;
+            return new ImageFile(path);
         }
-        img.resize(width, height);
+        ImageFile img = new ImageFile(path, width, height);
         if (cache.get(key) == null) {
             cache.put(key, new HashMap<>());
         }

--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -72,9 +72,9 @@ public class DrawObject extends AbstractDrawObject {
     public DrawObject(int currentRound, RobotType type, Team team, int id,
                       DrawState state) {
         super(currentRound, type, team, id);
-        img = ir.getResource(info, getAvatarPath(info), !type.isBuilding);
         maxHealth = type.maxHealth;
         overallstate = state;
+        loadImage();
     }
 
 
@@ -86,12 +86,26 @@ public class DrawObject extends AbstractDrawObject {
     }
 
     public static void loadAll() {
+        int spriteSize = Math.round(RenderConfiguration.getInstance().getSpriteSize());
         for (RobotType type : RobotType.values()) {
             for (Team team : Team.values()) {
                 RobotInfo robotInfo = new RobotInfo(type, team);
-                ir.getResource(robotInfo, getAvatarPath(robotInfo), !type
-                        .isBuilding);
+                ir.getResource(robotInfo, getAvatarPath(robotInfo),
+                        spriteSize, spriteSize);
             }
+        }
+    }
+
+    private int prevSpriteSize = -1;
+    private void loadImage() {
+        // Reloads "img", the ImageFile for the sprite, if the target spriteSize
+        // changes.
+        int spriteSize = Math.round(RenderConfiguration.getInstance()
+                .getSpriteSize());
+        if (spriteSize != prevSpriteSize) {
+            img = ir.getResource(info, getAvatarPath(info), spriteSize,
+                    spriteSize);
+            prevSpriteSize = spriteSize;
         }
     }
 
@@ -107,7 +121,7 @@ public class DrawObject extends AbstractDrawObject {
     @Override
     public void setType(RobotType type) {
         super.setType(type);
-        img = ir.getResource(info, getAvatarPath(info), !type.isBuilding);
+        loadImage();
     }
 
     private int getViewRange() {
@@ -149,6 +163,8 @@ public class DrawObject extends AbstractDrawObject {
 
     public void draw(Graphics2D g2, boolean focused, boolean lastRow, int
             layer) {
+        // Reload the image, in case the screen was resized.
+        loadImage();
         if (layer == 0) {
             if (RenderConfiguration.showRangeHatch() && focused) {
                 drawRangeHatch(g2);
@@ -385,11 +401,7 @@ public class DrawObject extends AbstractDrawObject {
     }
 
     private BufferedImage getTypeSprite() {
-        if (info.type.isBuilding) {
-            return img.image;
-        } else {
-            return ((SpriteSheetFile) img).spriteForDirection(dir);
-        }
+        return img.image;
     }
 
     public ExplosionAnim createDeathExplosionAnim(boolean unused) {


### PR DESCRIPTION
ImageResource is a static variable within DrawObject that can return a sprite for each possible <RobotType, Image dimensions> combination, caching results so it doesn't have to recompute resizes. Because this resize algorithm is smarter than the previous one, the images turn up better when the sprites are tiny.

The improvement isn't that big, unfortunately, but perhaps there's a better image resizing algorithm for sprites.

Before:

![screen shot 2016-01-13 at 7 53 59 pm](https://cloud.githubusercontent.com/assets/1474709/12312690/718e62b8-ba2f-11e5-9735-b5af3a1fb2ca.png)


After:
![screen shot 2016-01-13 at 7 53 16 pm](https://cloud.githubusercontent.com/assets/1474709/12312695/76f0f914-ba2f-11e5-8ae7-dafa6f9a0e36.png)
