### PR TITLE
Display true zombie health during outbreak

### DIFF
--- a/src/main/battlecode/client/viewer/render/DrawObject.java
+++ b/src/main/battlecode/client/viewer/render/DrawObject.java
@@ -71,7 +71,7 @@ public class DrawObject extends AbstractDrawObject {
     public DrawObject(int currentRound, RobotType type, Team team, int id,
                       DrawState state) {
         super(currentRound, type, team, id);
-        maxHealth = type.maxHealth;
+        maxHealth = type.maxHealth(currentRound);
         overallstate = state;
         loadImage(true);
     }


### PR DESCRIPTION
Need to use the actual max health of a zombie spawned during outbreaks, or else the zombie will appear to be max health when it actually isn't (if it's taken a small amount of damage).

Resolves https://github.com/battlecode/battlecode-client/issues/88